### PR TITLE
Update Display.cpp - 3 decimal places / freq.

### DIFF
--- a/tinyGS-SophyGS/src/Display/Display.cpp
+++ b/tinyGS-SophyGS/src/Display/Display.cpp
@@ -183,7 +183,7 @@ void drawFrame3(OLEDDisplay *display, OLEDDisplayUiState* state, int16_t x, int1
   display->setFont(ArialMT_Plain_10);
   display->drawString(x,  y,  status.modeminfo.satellite);
   display->setTextAlignment(TEXT_ALIGN_CENTER);
-  display->drawString(64+ x,  12 + y,  String(status.modeminfo.modem_mode) + " @ " + String(status.modeminfo.frequency) + "MHz");
+  display->drawString(64+ x,  12 + y,  String(status.modeminfo.modem_mode) + " @ " + String(status.modeminfo.frequency, 3) + "MHz");
   //display->drawString(x,  12 + y, "F:" );
   //display->setTextAlignment(TEXT_ALIGN_RIGHT);
   


### PR DESCRIPTION
Show -3- decimal places on OLED display.  While often zero, if a frequency is set that DOES use the third decimal place, it's nice to see it on the rotating OLED display since there is plenty of room